### PR TITLE
feature(add support for Stripe::setApiVersion)

### DIFF
--- a/src/Gateways/StripeGateway.php
+++ b/src/Gateways/StripeGateway.php
@@ -84,5 +84,9 @@ class StripeGateway implements Gateway
         }
 
         Stripe::setApiKey(env('STRIPE_SECRET'));
+        
+        if ($version = env('STRIPE_API_VERSION')) {
+            Stripe::setApiVersion($version);
+        }
     }
 }


### PR DESCRIPTION
Closes #283. This is an optional feature and will only be applied when the `STRIPE_API_VERSION` environment variable is present.