### PR TITLE
Fixed issue when checking out a product with only a single item in stock

### DIFF
--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -167,7 +167,7 @@ class CheckoutController extends BaseActionController
                         $stockCount = $product->get('stock') - $item['quantity'];
 
                         // Need to do this check before actually setting the stock
-                        if ($stockCount <= 0) {
+                        if ($stockCount < 0) {
                             event(new StockRunOut($product, $stockCount));
 
                             throw new CheckoutProductHasNoStockException($product);
@@ -188,10 +188,10 @@ class CheckoutController extends BaseActionController
                     $variant = $product->variant($item['variant']['variant'] ?? $item['variant']);
 
                     if ($variant->stockCount() !== null) {
-                        $stockCount = $variant->stockCount();
+                        $stockCount = $variant->stockCount() - $item['quantity'];
 
                         // Need to do this check before actually setting the stock
-                        if ($stockCount <= 0) {
+                        if ($stockCount < 0) {
                             event(new StockRunOut($product, $stockCount, $variant));
 
                             throw new CheckoutProductHasNoStockException($product, $variant);


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request fixes #477 by changing the stock change to a 'less than' rather than a 'less than or greater than'. In my testing, this seems to fix the issue.

I've also added two tests to confirm the fix does the job so it doesn't come back and bite again.