### PR TITLE
Price callbacks

### DIFF
--- a/docs/kb-articles.md
+++ b/docs/kb-articles.md
@@ -5,6 +5,7 @@ title: KB Articles
 I've written up a couple of articles to point towards the best practices when doing common e-commerce things in Simple Commerce.
 
 * [Customising the receipt view](/kb-articles/customising-receipt)
+* [Dynamic Pricing](/kb-articles/dynamic-pricing)
 * [Version Control Strategies](/kb-articles/version-control-strategies)
 * [Storing Orders on a Customer](/kb-articles/storing-orders-on-customer)
 * [Using an existing collection for Simple Commerce Products](/kb-articles/existing-collection-for-products)

--- a/docs/kb-articles/dynamic-pricing.md
+++ b/docs/kb-articles/dynamic-pricing.md
@@ -1,0 +1,40 @@
+---
+title: Dynamic Pricing
+---
+
+Depending on your use case, there may be situations where you need to use 'dynamic prices' for products depending on factors (eg. if customer is logged in, if customer is VIP, if it's a Friday, etc). Guess what - that's possible with Simple Commerce!
+
+Essentially, the way it works is we provide a method for you to register a callback. Inside that callback you can do whatever decisioning you need to do to determine the price.
+
+```php
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DoubleThreeDigital\SimpleCommerce\Contracts\Product;
+
+SimpleCommerce::productPriceHook(function (Order $order, Product $product) {
+    if (now()->isWeekend()) {
+        return 1750;
+    }
+
+    return 1500;
+});
+```
+
+Remember that you'll need to return the price as an integer. The above example returns `£17.50` or `£15.00` as prices.
+
+An alternative method is also available for [variant products](/product-variants).
+
+```php
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DoubleThreeDigital\SimpleCommerce\Contracts\Product;
+use DoubleThreeDigital\SimpleCommerce\Products\ProductVariant;
+
+SimpleCommerce::productVariantPriceHook(function (Order $order, Product $product, ProductVariant $variant) {
+    if (now()->isWeekend()) {
+        return 1750;
+    }
+
+    return 1500;
+});
+```
+
+> Note: These methods will not make any change to the price displayed to customers or stored in your products. They're only used when 'calculating' line items (eg. when an item is added to the cart, quantity changed, etc).

--- a/src/SimpleCommerce.php
+++ b/src/SimpleCommerce.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\SimpleCommerce;
 
+use Closure;
 use Illuminate\Support\Str;
 use Statamic\Facades\Collection;
 use Statamic\Statamic;
@@ -9,6 +10,9 @@ use Statamic\Statamic;
 class SimpleCommerce
 {
     protected static $gateways = [];
+
+    public static $productPriceHook;
+    public static $productVariantPriceHook;
 
     public static function bootGateways()
     {
@@ -99,5 +103,19 @@ class SimpleCommerce
     public static function customerDriver(): array
     {
         return config('simple-commerce.content.customers');
+    }
+
+    public static function productPriceHook(Closure $callback): self
+    {
+        static::$productPriceHook = $callback;
+
+        return (new static);
+    }
+
+    public static function productVariantPriceHook(Closure $callback): self
+    {
+        static::$productVariantPriceHook = $callback;
+
+        return (new static);
     }
 }

--- a/tests/Orders/CalculatorTest.php
+++ b/tests/Orders/CalculatorTest.php
@@ -9,6 +9,7 @@ use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\Address;
 use DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use DoubleThreeDigital\SimpleCommerce\Tests\SetupCollections;
 use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
@@ -608,6 +609,103 @@ class CalculatorTest extends TestCase
         $this->assertSame($calculate['coupon_total'], 12000);
 
         $this->assertSame($calculate['items'][0]['total'], 10000);
+    }
+
+    /** @test */
+    public function ensure_product_price_hook_is_used_to_determine_price_of_product()
+    {
+        $product = Product::create([
+            'price' => 100,
+        ]);
+
+        SimpleCommerce::productPriceHook(function ($order, $product) {
+            return $product->get('price') * 2;
+        });
+
+        $cart = Order::create([
+            'is_paid'     => false,
+            'grand_total' => 0,
+            'items_total' => 0,
+            'items'       => [
+                [
+                    'product'  => $product->id,
+                    'quantity' => 1,
+                    'total'    => 0,
+                ],
+            ],
+        ]);
+
+        $calculate = (new Calculator())->calculate($cart);
+
+        $this->assertIsArray($calculate);
+
+        $this->assertSame($calculate['grand_total'], 240);
+        $this->assertSame($calculate['items_total'], 200);
+        $this->assertSame($calculate['shipping_total'], 0);
+        $this->assertSame($calculate['tax_total'], 40);
+        $this->assertSame($calculate['coupon_total'], 0);
+
+        $this->assertSame($calculate['items'][0]['total'], 200);
+    }
+
+    /** @test */
+    public function ensure_product_variant_price_hook_is_used_to_determine_price_of_product_variant()
+    {
+        $product = Product::create([
+            'product_variants' => [
+                'variants' => [
+                    [
+                        'name'   => 'Colours',
+                        'values' => [
+                            'Red',
+                        ],
+                    ],
+                    [
+                        'name'   => 'Sizes',
+                        'values' => [
+                            'Small',
+                        ],
+                    ],
+                ],
+                'options' => [
+                    [
+                        'key'     => 'Red_Small',
+                        'variant' => 'Red Small',
+                        'price'   => 100,
+                    ],
+                ],
+            ],
+        ]);
+
+        SimpleCommerce::productVariantPriceHook(function ($order, $product, $variant) {
+            return $variant->price() * 2;
+        });
+
+        $cart = Order::create([
+            'is_paid'     => false,
+            'grand_total' => 0,
+            'items_total' => 0,
+            'items'       => [
+                [
+                    'product'  => $product->id,
+                    'variant'  => 'Red_Small',
+                    'quantity' => 1,
+                    'total'    => 0,
+                ],
+            ],
+        ]);
+
+        $calculate = (new Calculator())->calculate($cart);
+
+        $this->assertIsArray($calculate);
+
+        $this->assertSame($calculate['grand_total'], 240);
+        $this->assertSame($calculate['items_total'], 200);
+        $this->assertSame($calculate['shipping_total'], 0);
+        $this->assertSame($calculate['tax_total'], 40);
+        $this->assertSame($calculate['coupon_total'], 0);
+
+        $this->assertSame($calculate['items'][0]['total'], 200);
     }
 }
 


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request introduces two new methods which allow for dynamically setting the price of products/variants when they're added to the cart.

This can be useful when you need to provide different prices to customers as apposed to guests or the customer has paid more than £x amount before.

## Example

```php
use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
use DoubleThreeDigital\SimpleCommerce\Contracts\Product;

SimpleCommerce::productPriceHook(function (Order $order, Product $product) {
    if (now()->isWeekend()) {
        return 1750;
    }

    return 1500;
});
```
