### PR TITLE
IsEntry fixes

### DIFF
--- a/src/Support/Traits/IsEntry.php
+++ b/src/Support/Traits/IsEntry.php
@@ -55,13 +55,13 @@ trait IsEntry
     {
         $this->entry = null;
 
-        $this->id = isset($data['id']) ? $data['id'] : Stache::generateId();
+        $this->id = !is_null($this->id) ? $this->id : Stache::generateId();
         $this->site = $site !== '' ? $site : SiteAPI::current()->handle();
-        $this->slug = isset($data['slug']) ? $data['slug'] : null;
-        $this->published = isset($data['published']) ? $data['published'] : false;
+        $this->slug = !is_null($this->slug) ? $this->slug : '';
+        $this->published = !is_null($this->published) ? $this->published : false;
 
-        if (! $this->slug) {
-            $this->slug = $this->id;
+        if (! $this->slug && isset($data['slug'])) {
+            $this->slug = $data['slug'];
         }
 
         if (! $this->published && isset($data['published'])) {

--- a/src/Support/Traits/IsEntry.php
+++ b/src/Support/Traits/IsEntry.php
@@ -55,7 +55,9 @@ trait IsEntry
     {
         $this->entry = null;
 
-        $this->id = !is_null($this->id) ? $this->id : Stache::generateId();
+        // $this->id = !is_null($this->id) ? $this->id : Stache::generateId();
+        $this->id = isset($data['id']) ? $data['id'] : Stache::generateId();
+        
         $this->site = $site !== '' ? $site : SiteAPI::current()->handle();
         $this->slug = !is_null($this->slug) ? $this->slug : '';
         $this->published = !is_null($this->published) ? $this->published : false;

--- a/src/Support/Traits/IsEntry.php
+++ b/src/Support/Traits/IsEntry.php
@@ -53,13 +53,15 @@ trait IsEntry
 
     public function create(array $data = [], string $site = ''): self
     {
-        $this->id = !is_null($this->id) ? $this->id : Stache::generateId();
-        $this->site = $site !== '' ? $site : SiteAPI::current()->handle();
-        $this->slug = !is_null($this->slug) ? $this->slug : '';
-        $this->published = !is_null($this->published) ? $this->published : false;
+        $this->entry = null;
 
-        if (! $this->slug && isset($data['slug'])) {
-            $this->slug = $data['slug'];
+        $this->id = isset($data['id']) ? $data['id'] : Stache::generateId();
+        $this->site = $site !== '' ? $site : SiteAPI::current()->handle();
+        $this->slug = isset($data['slug']) ? $data['slug'] : null;
+        $this->published = isset($data['published']) ? $data['published'] : false;
+
+        if (! $this->slug) {
+            $this->slug = $this->id;
         }
 
         if (! $this->published && isset($data['published'])) {
@@ -102,6 +104,8 @@ trait IsEntry
         if (method_exists($this, 'beforeSaved')) {
             $this->beforeSaved();
         }
+
+        ray($this);
 
         $this->entry->save();
 


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

Just spent an hour or two trying to debug somethings around why orders weren't saving properly when building out an importer (only a single entry was saved but all orders hit the `create` method)

Essentially, they seemed to keep an instance of the `$entry` property between calls, meaning an `$entry` would exist when `save`ing which would mean the original entry would be continuously updated.