### PR TITLE
Add a couple of omissions in the gateway docs

### DIFF
--- a/docs/gateways/paypal.md
+++ b/docs/gateways/paypal.md
@@ -79,6 +79,7 @@ A rough example of a PayPal implementation is provided below.
 ```antlers
 <div id="paypal-button"></div>
 <input id="paypal-payment-id" type="hidden" name="payment_id">
+<input type="hidden" name="gateway" value="DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\PayPalGateway">
 <script src="https://www.paypal.com/sdk/js?client-id={{ gateway-config:client_id }}&currency={{ result.currency_code }}"></script>
 <script>
     paypal.Buttons({

--- a/docs/gateways/stripe.md
+++ b/docs/gateways/stripe.md
@@ -54,11 +54,17 @@ A rough example of a Stripe Elements implementation is provided below.
         }).then(function (result) {
           	if (result.paymentIntent.status === 'succeeded') {
             	document.getElementById('stripePaymentMethod').value = result.paymentIntent.payment_method
+            	document.getElementById('checkout-form').submit();
             } else if (result.error) {
              	// Deal with errors
             }
         })
     }
+    
+    document.getElementById('checkout-form').addEventListener('submit', (e) => {
+        e.preventDefault()
+	confirmPayment();
+    })
 </script>
 ```
 

--- a/docs/gateways/stripe.md
+++ b/docs/gateways/stripe.md
@@ -54,7 +54,7 @@ A rough example of a Stripe Elements implementation is provided below.
         }).then(function (result) {
           	if (result.paymentIntent.status === 'succeeded') {
             	document.getElementById('stripePaymentMethod').value = result.paymentIntent.payment_method
-            	document.getElementById('checkout-form').submit();
+            	document.getElementById('checkout-form').submit()
             } else if (result.error) {
              	// Deal with errors
             }
@@ -63,7 +63,7 @@ A rough example of a Stripe Elements implementation is provided below.
     
     document.getElementById('checkout-form').addEventListener('submit', (e) => {
         e.preventDefault()
-	confirmPayment();
+	confirmPayment()
     })
 </script>
 ```


### PR DESCRIPTION
I spotted a couple of things missing from the gateway code examples that meant they were incomplete and wouldn't work if you just copy and pasted.