### PR TITLE
Add state/county field to addresses

### DIFF
--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -107,6 +107,7 @@ Let's start with the letting the user enter their shipping address. In our start
     <input type="text" name="shipping_name" placeholder="Name" value="{{ old:shipping_name }}">
     <input type="text" name="shipping_address" placeholder="Address" value="{{ old:shipping_address }}">
     <input type="text" name="shipping_city" placeholder="City" value="{{ old:shipping_city }}">
+    <input type="text" name="shipping_state" placeholder="County" value="{{ old:shipping_state }}">
     <select name="shipping_country" value="{{ old:shipping_country }}">
         {{ sc:countries }}
             <option value="{{ iso }}">{{ name }}</option>

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -107,7 +107,7 @@ Let's start with the letting the user enter their shipping address. In our start
     <input type="text" name="shipping_name" placeholder="Name" value="{{ old:shipping_name }}">
     <input type="text" name="shipping_address" placeholder="Address" value="{{ old:shipping_address }}">
     <input type="text" name="shipping_city" placeholder="City" value="{{ old:shipping_city }}">
-    <input type="text" name="shipping_state" placeholder="County" value="{{ old:shipping_state }}">
+    <input type="text" name="shipping_region" placeholder="Region" value="{{ old:shipping_region }}">
     <select name="shipping_country" value="{{ old:shipping_country }}">
         {{ sc:countries }}
             <option value="{{ iso }}">{{ name }}</option>

--- a/resources/blueprints/collections/orders/order.yaml
+++ b/resources/blueprints/collections/orders/order.yaml
@@ -147,6 +147,14 @@ sections:
           display: 'Shipping City'
           read_only: true
       -
+        handle: shipping_county
+        field:
+          input_type: text
+          type: text
+          listable: false
+          display: 'Shipping County'
+          read_only: true
+      -
         handle: shipping_country
         field:
           max_items: 1
@@ -205,6 +213,16 @@ sections:
           type: text
           listable: false
           display: 'Billing City'
+          unless:
+            use_shipping_address_for_billing: 'equals true'
+          read_only: true
+      -
+        handle: billing_county
+        field:
+          input_type: text
+          type: text
+          listable: false
+          display: 'Billing County'
           unless:
             use_shipping_address_for_billing: 'equals true'
           read_only: true

--- a/resources/blueprints/collections/orders/order.yaml
+++ b/resources/blueprints/collections/orders/order.yaml
@@ -147,12 +147,12 @@ sections:
           display: 'Shipping City'
           read_only: true
       -
-        handle: shipping_county
+        handle: shipping_region
         field:
           input_type: text
           type: text
           listable: false
-          display: 'Shipping County'
+          display: 'Shipping Region'
           read_only: true
       -
         handle: shipping_country
@@ -217,12 +217,12 @@ sections:
             use_shipping_address_for_billing: 'equals true'
           read_only: true
       -
-        handle: billing_county
+        handle: billing_region
         field:
           input_type: text
           type: text
           listable: false
-          display: 'Billing County'
+          display: 'Billing Region'
           unless:
             use_shipping_address_for_billing: 'equals true'
           read_only: true

--- a/resources/views/receipt.antlers.html
+++ b/resources/views/receipt.antlers.html
@@ -44,7 +44,7 @@
                     <p class="text-xs">{{ billing_name }}</p>
                     <p class="text-xs">{{ billing_address }}</p>
                     <p class="text-xs">{{ billing_city }}</p>
-                    <p class="text-xs">{{ billing_state }}</p>
+                    <p class="text-xs">{{ billing_region }}</p>
                     <p class="text-xs">{{ billing_country }}</p>
                     <p class="text-xs">{{ billing_zip_code }}</p>
                 </td>
@@ -56,7 +56,7 @@
                     <p class="text-xs">{{ shipping_name }}</p>
                     <p class="text-xs">{{ shipping_address }}</p>
                     <p class="text-xs">{{ shipping_city }}</p>
-                    <p class="text-xs">{{ shipping_state }}</p>
+                    <p class="text-xs">{{ shipping_region }}</p>
                     <p class="text-xs">{{ shipping_country }}</p>
                     <p class="text-xs">{{ shipping_zip_code }}</p>
                 </td>

--- a/resources/views/receipt.antlers.html
+++ b/resources/views/receipt.antlers.html
@@ -44,6 +44,7 @@
                     <p class="text-xs">{{ billing_name }}</p>
                     <p class="text-xs">{{ billing_address }}</p>
                     <p class="text-xs">{{ billing_city }}</p>
+                    <p class="text-xs">{{ billing_state }}</p>
                     <p class="text-xs">{{ billing_country }}</p>
                     <p class="text-xs">{{ billing_zip_code }}</p>
                 </td>
@@ -55,6 +56,7 @@
                     <p class="text-xs">{{ shipping_name }}</p>
                     <p class="text-xs">{{ shipping_address }}</p>
                     <p class="text-xs">{{ shipping_city }}</p>
+                    <p class="text-xs">{{ shipping_state }}</p>
                     <p class="text-xs">{{ shipping_country }}</p>
                     <p class="text-xs">{{ shipping_zip_code }}</p>
                 </td>

--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -208,7 +208,7 @@ class PayPalGateway extends BaseGateway implements Gateway
                     ->set('shipping_name', $paypalShipping['name']['full_name'])
                     ->set('shipping_address', $paypalShipping['address']['address_line_1'])
                     ->set('shipping_city', $paypalShipping['address']['admin_area_2'])
-                    ->set('shipping_state', $paypalShipping['address']['admin_area_1'])
+                    ->set('shipping_county', $paypalShipping['address']['admin_area_1'])
                     ->set('shipping_country', $paypalShipping['address']['country_code'])
                     ->set('shipping_postal_code', $paypalShipping['address']['postal_code'])
                     ->save();

--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -208,7 +208,7 @@ class PayPalGateway extends BaseGateway implements Gateway
                     ->set('shipping_name', $paypalShipping['name']['full_name'])
                     ->set('shipping_address', $paypalShipping['address']['address_line_1'])
                     ->set('shipping_city', $paypalShipping['address']['admin_area_2'])
-                    ->set('shipping_county', $paypalShipping['address']['admin_area_1'])
+                    ->set('shipping_region', $paypalShipping['address']['admin_area_1'])
                     ->set('shipping_country', $paypalShipping['address']['country_code'])
                     ->set('shipping_postal_code', $paypalShipping['address']['postal_code'])
                     ->save();

--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -207,7 +207,8 @@ class PayPalGateway extends BaseGateway implements Gateway
                 $order
                     ->set('shipping_name', $paypalShipping['name']['full_name'])
                     ->set('shipping_address', $paypalShipping['address']['address_line_1'])
-                    ->set('shipping_city', $paypalShipping['address']['admin_area_1'])
+                    ->set('shipping_city', $paypalShipping['address']['admin_area_2'])
+                    ->set('shipping_state', $paypalShipping['address']['admin_area_1'])
                     ->set('shipping_country', $paypalShipping['address']['country_code'])
                     ->set('shipping_postal_code', $paypalShipping['address']['postal_code'])
                     ->save();

--- a/src/Orders/Address.php
+++ b/src/Orders/Address.php
@@ -8,17 +8,17 @@ class Address
     protected $addressLine1;
     protected $addressLine2;
     protected $city;
-    protected $state;
+    protected $region;
     protected $country;
     protected $zipCode;
 
-    public function __construct($name, $addressLine1, $addressLine2, $city, $state, $country, $zipCode)
+    public function __construct($name, $addressLine1, $addressLine2, $city, $country, $zipCode, $region = null)
     {
         $this->name         = $name;
         $this->addressLine1 = $addressLine1;
         $this->addressLine2 = $addressLine2;
         $this->city         = $city;
-        $this->state        = $state;
+        $this->region       = $region;
         $this->country      = $country;
         $this->zipCode      = $zipCode;
     }
@@ -30,7 +30,7 @@ class Address
             'address_line_1' => $this->addressLine1,
             'address_line_2' => $this->addressLine2,
             'city'           => $this->city,
-            'state'          => $this->state,
+            'region'         => $this->region,
             'country'        => $this->country,
             'zip_code'       => $this->zipCode,
         ];
@@ -63,9 +63,9 @@ class Address
         return $this->city;
     }
 
-    public function state(): ?string
+    public function region(): ?string
     {
-        return $this->state;
+        return $this->region;
     }
 
     public function country(): ?string

--- a/src/Orders/Address.php
+++ b/src/Orders/Address.php
@@ -8,15 +8,17 @@ class Address
     protected $addressLine1;
     protected $addressLine2;
     protected $city;
+    protected $state;
     protected $country;
     protected $zipCode;
 
-    public function __construct($name, $addressLine1, $addressLine2, $city, $country, $zipCode)
+    public function __construct($name, $addressLine1, $addressLine2, $city, $state, $country, $zipCode)
     {
         $this->name         = $name;
         $this->addressLine1 = $addressLine1;
         $this->addressLine2 = $addressLine2;
         $this->city         = $city;
+        $this->state        = $state;
         $this->country      = $country;
         $this->zipCode      = $zipCode;
     }
@@ -28,6 +30,7 @@ class Address
             'address_line_1' => $this->addressLine1,
             'address_line_2' => $this->addressLine2,
             'city'           => $this->city,
+            'state'          => $this->state,
             'country'        => $this->country,
             'zip_code'       => $this->zipCode,
         ];
@@ -58,6 +61,11 @@ class Address
     public function city(): ?string
     {
         return $this->city;
+    }
+
+    public function state(): ?string
+    {
+        return $this->state;
     }
 
     public function country(): ?string

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -63,6 +63,7 @@ class Order implements Contract
             $this->get('billing_address') ?? $this->get('billing_address_line1'),
             $this->get('billing_address_line2'),
             $this->get('billing_city'),
+            $this->get('billing_state') ?? $this->get('billing_county'),
             $this->get('billing_country'),
             $this->get('billing_zip_code') ?? $this->get('billing_postal_code')
         );
@@ -79,6 +80,7 @@ class Order implements Contract
             $this->get('shipping_address') ?? $this->get('shipping_address_line1'),
             $this->get('shipping_address_line2'),
             $this->get('shipping_city'),
+            $this->get('shipping_state') ?? $this->get('shipping_county'),
             $this->get('shipping_country'),
             $this->get('shipping_zip_code') ?? $this->get('shipping_postal_code')
         );

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -63,9 +63,9 @@ class Order implements Contract
             $this->get('billing_address') ?? $this->get('billing_address_line1'),
             $this->get('billing_address_line2'),
             $this->get('billing_city'),
-            $this->get('billing_state') ?? $this->get('billing_county'),
             $this->get('billing_country'),
-            $this->get('billing_zip_code') ?? $this->get('billing_postal_code')
+            $this->get('billing_zip_code') ?? $this->get('billing_postal_code'),
+            $this->get('billing_region')
         );
     }
 
@@ -80,9 +80,9 @@ class Order implements Contract
             $this->get('shipping_address') ?? $this->get('shipping_address_line1'),
             $this->get('shipping_address_line2'),
             $this->get('shipping_city'),
-            $this->get('shipping_state') ?? $this->get('shipping_county'),
             $this->get('shipping_country'),
-            $this->get('shipping_zip_code') ?? $this->get('shipping_postal_code')
+            $this->get('shipping_zip_code') ?? $this->get('shipping_postal_code'),
+            $this->get('shipping_region')
         );
     }
 


### PR DESCRIPTION
This PR adds state/county support to the shipping and billing addresses.

Just like the zip/postal code this will allow a field named `*_state` (US) or `*_county` (UK). As SC defaults to `*_zip_code` for zip/postal code this mirrors that convention by defaulting to `*_state`.

I've also updated the PayPal gateway as the shipping address PayPal provides contains values for both city and state:

> **admin_area_2** 
> A city, town, or village. Smaller than admin_area_level_1.
> 
> **admin_area_1**
> The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision. Format for postal delivery. For example, CA and not California. Value, by country, is:
> UK. A county.
> US. A state.

https://developer.paypal.com/docs/api/orders/v2/

In most places SC uses the US named fields by default, but there are a couple of places where the UK named fields are used. I've mirrored these because I wanted to be consistent with the conventions already in place in SC, but I'm not sure if any of this needs to be tidied up for consistency?

1. The order blueprint has UK named fields called `*_county`
    * This is because it already has `*_postal_code` fields, not `*_zip_code` fields
2. The shipping docs page has a US named field called `*_state` but the placeholder is County
    * This is because it already has a `*_zip_code` field with a placeholder of Postal Code, not Zip Code
3. The PP gateway sets a UK named field called `*_county`
    * This is because it already sets a `*_postal_code` field, not `*_zip_code`
    * I dont know if this is a problem or not, does that mean if you're using `*_zip_code` and `*_state` they wont be updated from the PP data?