### PR TITLE
Check variant exists before checking stock

### DIFF
--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -78,7 +78,7 @@ class CartItemController extends BaseActionController
         } elseif ($product->purchasableType() === 'variants') {
             $variant = $product->variant($request->get('variant'));
 
-            if ($variant && $variant->stockCount() !== null && $variant->stockCount() < $request->quantity) {
+            if ($variant !== null && $variant->stockCount() !== null && $variant->stockCount() < $request->quantity) {
                 return $this->withErrors($request, __("There's not enough stock to fulfil the quantity you selected. Please try again later."));
             }
         }

--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -78,7 +78,7 @@ class CartItemController extends BaseActionController
         } elseif ($product->purchasableType() === 'variants') {
             $variant = $product->variant($request->get('variant'));
 
-            if ($variant->stockCount() !== null && $variant->stockCount() < $request->quantity) {
+            if ($variant && $variant->stockCount() !== null && $variant->stockCount() < $request->quantity) {
                 return $this->withErrors($request, __("There's not enough stock to fulfil the quantity you selected. Please try again later."));
             }
         }

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -187,7 +187,7 @@ class CheckoutController extends BaseActionController
                 if ($product->purchasableType() === 'variants') {
                     $variant = $product->variant($item['variant']['variant'] ?? $item['variant']);
 
-                    if ($variant->stockCount() !== null) {
+                    if ($variant !== null && $variant->stockCount() !== null) {
                         $stockCount = $variant->stockCount() - $item['quantity'];
 
                         // Need to do this check before actually setting the stock


### PR DESCRIPTION
I'm using dynamically generated variants on a site and the latest update errors when SC tries to check the stock, as the variant doesn't actually exist in the data. This fixes that.