### PR TITLE
Eloquent Driver improvements

### DIFF
--- a/src/Support/Traits/IsEntry.php
+++ b/src/Support/Traits/IsEntry.php
@@ -58,21 +58,23 @@ trait IsEntry
         }
 
         $this->site = $site !== '' ? $site : SiteAPI::current()->handle();
-        $this->slug = !is_null($this->slug) ? $this->slug : '';
-        $this->published = !is_null($this->published) ? $this->published : false;
+        $this->published = false;
 
-        if (! $this->slug && isset($data['slug'])) {
+        // $this->slug = !is_null($this->slug) ? $this->slug : '';
+        // $this->published = !is_null($this->published) ? $this->published : false;
+
+        if (isset($data['slug'])) {
             $this->slug = $data['slug'];
         }
 
-        if (! $this->published && isset($data['published'])) {
+        if (isset($data['published'])) {
             $this->published = $data['published'];
         }
 
         $data = array_merge($data, $this->defaultFieldsInBlueprint());
 
         $this->data(
-            Arr::except($data, ['id', 'site', 'slug', 'publish'])
+            Arr::except($data, ['id', 'site', 'slug', 'published'])
         );
 
         $this->save();
@@ -82,7 +84,7 @@ trait IsEntry
 
     public function save(): self
     {
-        if (!$this->entry) {
+        if (! $this->entry) {
             $this->entry = EntryAPI::make()
                 ->locale($this->site);
 
@@ -110,6 +112,8 @@ trait IsEntry
         }
 
         $this->entry->save();
+
+        $this->id = $this->entry->id();
 
         if (method_exists($this, 'afterSaved')) {
             $this->afterSaved();

--- a/src/Support/Traits/IsEntry.php
+++ b/src/Support/Traits/IsEntry.php
@@ -60,9 +60,6 @@ trait IsEntry
         $this->site = $site !== '' ? $site : SiteAPI::current()->handle();
         $this->published = false;
 
-        // $this->slug = !is_null($this->slug) ? $this->slug : '';
-        // $this->published = !is_null($this->published) ? $this->published : false;
-
         if (isset($data['slug'])) {
             $this->slug = $data['slug'];
         }


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request provides some fixes/improvements when using the Eloquent Entries driver alongside Simple Commerce. Included:

* Previously an order (or anything else for that matter) could not be created via SC's API's
* Fixed a bug where you'd end up with duplicate carts.

## Related Issues

<!-- 
  Does this PR fix any open issues? 
  -- If so, please do something like this: 'Closes #1'
-->

Fixes #486