### PR TITLE
[6.x] Fix missing gateway data with Mollie

### DIFF
--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -96,6 +96,9 @@ class MollieGateway extends BaseGateway implements Gateway
                 return;
             }
 
+            $order->gatewayData(data: (array) $payment);
+            $order->save();
+
             $this->markOrderAsPaid($order);
         }
 


### PR DESCRIPTION
This pull request fixes an issue where the Mollie Payment Gateway wasn't persisting any information about the payment, like the ID.

This lead to "Unknown" being displayed by the gateway fieldtype:

![image](https://github.com/duncanmcclean/simple-commerce/assets/19637309/3eb1d509-47cf-4c2b-a05d-7abfb69ec70d)

Partially fixes #1026.