### PR TITLE
[8.x] Supports Laravel 13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php: [8.3, 8.4, 8.5]
-        laravel: [12.*]
+        laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "paypal/paypal-checkout-sdk": "^1.0",
         "pixelfear/composer-dist-plugin": "^0.1.0",
         "spatie/ignition": "^1.13",
-        "statamic/cms": "^6.0",
+        "statamic/cms": "^6.5",
         "stillat/proteus": "^4.0",
         "stripe/stripe-php": "^13.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,24 +31,24 @@
     "require": {
         "php": "^8.3",
         "ext-intl": "*",
-        "laravel/framework": "^12.0",
+        "laravel/framework": "^12.0 || ^13.0",
         "mollie/mollie-api-php": "^2.30.0",
         "moneyphp/money": "^4.0",
         "paypal/paypal-checkout-sdk": "^1.0",
         "pixelfear/composer-dist-plugin": "^0.1.0",
         "spatie/ignition": "^1.13",
-        "statamic/cms": "^6.0.0",
+        "statamic/cms": "^6.0",
         "stillat/proteus": "^4.0",
         "stripe/stripe-php": "^13.0"
     },
     "require-dev": {
         "laravel/pint": "dev-main",
-        "orchestra/testbench": "^10.8",
+        "orchestra/testbench": "^10.8 || ^11.0",
         "pestphp/pest": "^3.0 || ^4.1.4",
         "pestphp/pest-plugin-laravel": "^3.0 || ^4.0",
         "spatie/ray": "^1.17",
         "spatie/test-time": "^1.3",
-        "statamic-rad-pack/runway": "^9.0.0-alpha.5"
+        "statamic-rad-pack/runway": "^9.0"
     },
     "config": {
         "optimize-autoloader": true,
@@ -60,5 +60,7 @@
             "pixelfear/composer-dist-plugin": true,
             "pestphp/pest-plugin": true
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "pixelfear/composer-dist-plugin": "^0.1.0",
         "spatie/ignition": "^1.13",
         "statamic/cms": "^6.5",
-        "stillat/proteus": "^4.0",
+        "stillat/proteus": "^4.2.1",
         "stripe/stripe-php": "^13.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "pestphp/pest-plugin-laravel": "^3.0 || ^4.0",
         "spatie/ray": "^1.17",
         "spatie/test-time": "^1.3",
-        "statamic-rad-pack/runway": "^9.0"
+        "statamic-rad-pack/runway": "^9.2"
     },
     "config": {
         "optimize-autoloader": true,

--- a/config/simple-commerce.php
+++ b/config/simple-commerce.php
@@ -1,5 +1,12 @@
 <?php
 
+use DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository;
+use DuncanMcClean\SimpleCommerce\Gateways\Builtin\DummyGateway;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\Products\EntryProductRepository;
+use DuncanMcClean\SimpleCommerce\Shipping\FreeShipping;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\TaxEngine;
+
 return [
 
     /*
@@ -20,7 +27,7 @@ return [
 
             'shipping' => [
                 'methods' => [
-                    \DuncanMcClean\SimpleCommerce\Shipping\FreeShipping::class => [],
+                    FreeShipping::class => [],
                 ],
             ],
         ],
@@ -39,7 +46,7 @@ return [
     */
 
     'gateways' => [
-        \DuncanMcClean\SimpleCommerce\Gateways\Builtin\DummyGateway::class => [
+        DummyGateway::class => [
             'display' => 'Card',
         ],
     ],
@@ -110,7 +117,7 @@ return [
     |
     */
 
-    'tax_engine' => \DuncanMcClean\SimpleCommerce\Tax\Standard\TaxEngine::class,
+    'tax_engine' => TaxEngine::class,
 
     'tax_engine_config' => [
         // Basic Engine
@@ -161,17 +168,17 @@ return [
 
     'content' => [
         'customers' => [
-            'repository' => \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class,
+            'repository' => EntryCustomerRepository::class,
             'collection' => 'customers',
         ],
 
         'orders' => [
-            'repository' => \DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository::class,
+            'repository' => EntryOrderRepository::class,
             'collection' => 'orders',
         ],
 
         'products' => [
-            'repository' => \DuncanMcClean\SimpleCommerce\Products\EntryProductRepository::class,
+            'repository' => EntryProductRepository::class,
             'collection' => 'products',
         ],
     ],

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -2,6 +2,7 @@
 
 namespace DuncanMcClean\SimpleCommerce\Actions;
 
+use DuncanMcClean\SimpleCommerce\Coupons\Coupon;
 use Statamic\Actions\Action;
 
 class Delete extends Action
@@ -20,7 +21,7 @@ class Delete extends Action
     public function visibleTo($item)
     {
         switch (true) {
-            case $item instanceof \DuncanMcClean\SimpleCommerce\Coupons\Coupon:
+            case $item instanceof Coupon:
                 return true;
             default:
                 return false;
@@ -30,7 +31,7 @@ class Delete extends Action
     public function authorize($user, $item)
     {
         switch (true) {
-            case $item instanceof \DuncanMcClean\SimpleCommerce\Coupons\Coupon:
+            case $item instanceof Coupon:
                 return $user->can('delete coupons');
             default:
                 return false;

--- a/src/Console/Commands/PurgeCartOrdersCommand.php
+++ b/src/Console/Commands/PurgeCartOrdersCommand.php
@@ -3,6 +3,7 @@
 namespace DuncanMcClean\SimpleCommerce\Console\Commands;
 
 use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
 use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
 use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Console\Command;
@@ -23,7 +24,7 @@ class PurgeCartOrdersCommand extends Command
 
         $fourteenDaysFromNow = Carbon::now()->subDays(14);
 
-        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], \DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository::class)) {
+        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EntryOrderRepository::class)) {
             $fourteenDaysFromNow = $fourteenDaysFromNow->timestamp;
         }
 

--- a/src/Console/Commands/SwitchToDatabase.php
+++ b/src/Console/Commands/SwitchToDatabase.php
@@ -2,6 +2,10 @@
 
 namespace DuncanMcClean\SimpleCommerce\Console\Commands;
 
+use DuncanMcClean\SimpleCommerce\Customers\CustomerModel;
+use DuncanMcClean\SimpleCommerce\Customers\EloquentCustomerRepository;
+use DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\OrderModel;
 use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -111,12 +115,12 @@ class SwitchToDatabase extends Command
 
         ConfigWriter::edit('simple-commerce')
             ->replace('content.orders', [
-                'repository' => \DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository::class,
-                'model' => \DuncanMcClean\SimpleCommerce\Orders\OrderModel::class,
+                'repository' => EloquentOrderRepository::class,
+                'model' => OrderModel::class,
             ])
             ->replace('content.customers', [
-                'repository' => \DuncanMcClean\SimpleCommerce\Customers\EloquentCustomerRepository::class,
-                'model' => \DuncanMcClean\SimpleCommerce\Customers\CustomerModel::class,
+                'repository' => EloquentCustomerRepository::class,
+                'model' => CustomerModel::class,
             ])
             ->save();
 

--- a/src/Console/Commands/stubs/runway_config.php
+++ b/src/Console/Commands/stubs/runway_config.php
@@ -1,5 +1,8 @@
 <?php
 
+use DuncanMcClean\SimpleCommerce\Customers\CustomerModel;
+use DuncanMcClean\SimpleCommerce\Orders\OrderModel;
+
 return [
 
     /*
@@ -12,13 +15,13 @@ return [
     */
 
     'resources' => [
-        \DuncanMcClean\SimpleCommerce\Customers\CustomerModel::class => [
+        CustomerModel::class => [
             'name' => 'Customers',
             'handle' => 'customers',
             'hidden' => true,
         ],
 
-        \DuncanMcClean\SimpleCommerce\Orders\OrderModel::class => [
+        OrderModel::class => [
             'name' => 'Orders',
             'handle' => 'orders',
             'hidden' => true,

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -44,16 +44,16 @@ class Currency
         try {
             $money = new Money(str_replace('.', '', (int) $amount), new MoneyCurrency(self::get($site)['code']));
 
-            $numberFormatter = new NumberFormatter($site->locale(), \NumberFormatter::CURRENCY);
+            $numberFormatter = new NumberFormatter($site->locale(), NumberFormatter::CURRENCY);
 
             $currencyFormattingConfig = Config::get("simple-commerce.sites.{$site->handle()}.currency_formatting");
 
             if (isset($currencyFormattingConfig['decimal_separator'])) {
-                $numberFormatter->setSymbol(\NumberFormatter::MONETARY_SEPARATOR_SYMBOL, $currencyFormattingConfig['decimal_separator']);
+                $numberFormatter->setSymbol(NumberFormatter::MONETARY_SEPARATOR_SYMBOL, $currencyFormattingConfig['decimal_separator']);
             }
 
             if (isset($currencyFormattingConfig['thousand_separator'])) {
-                $numberFormatter->setSymbol(\NumberFormatter::MONETARY_GROUPING_SEPARATOR_SYMBOL, $currencyFormattingConfig['thousand_separator']);
+                $numberFormatter->setSymbol(NumberFormatter::MONETARY_GROUPING_SEPARATOR_SYMBOL, $currencyFormattingConfig['thousand_separator']);
             }
 
             $moneyFormatter = new IntlMoneyFormatter($numberFormatter, new ISOCurrencies);

--- a/src/Customers/EntryCustomerRepository.php
+++ b/src/Customers/EntryCustomerRepository.php
@@ -8,6 +8,7 @@ use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
 use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Statamic\Eloquent\Entries\EntryModel;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Stache;
 
@@ -141,7 +142,7 @@ class EntryCustomerRepository implements RepositoryContract
 
     protected function isUsingEloquentDriverWithIncrementingIds(): bool
     {
-        return config('statamic.eloquent-driver.entries.model') === \Statamic\Eloquent\Entries\EntryModel::class;
+        return config('statamic.eloquent-driver.entries.model') === EntryModel::class;
     }
 
     public static function bindings(): array

--- a/src/DebugbarDataCollector.php
+++ b/src/DebugbarDataCollector.php
@@ -2,10 +2,12 @@
 
 namespace DuncanMcClean\SimpleCommerce;
 
+use DebugBar\DataCollector\DataCollector;
+use DebugBar\DataCollector\Renderable;
 use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use Statamic\Facades\Site;
 
-class DebugbarDataCollector extends \DebugBar\DataCollector\DataCollector implements \DebugBar\DataCollector\Renderable
+class DebugbarDataCollector extends DataCollector implements Renderable
 {
     use CartDriver;
 

--- a/src/Facades/Coupon.php
+++ b/src/Facades/Coupon.php
@@ -6,7 +6,7 @@ use DuncanMcClean\SimpleCommerce\Contracts\CouponRepository;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \DuncanMcClean\SimpleCommerce\Contracts\CouponRepository
+ * @see CouponRepository
  */
 class Coupon extends Facade
 {

--- a/src/Facades/Customer.php
+++ b/src/Facades/Customer.php
@@ -6,7 +6,7 @@ use DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository
+ * @see CustomerRepository
  */
 class Customer extends Facade
 {

--- a/src/Facades/Order.php
+++ b/src/Facades/Order.php
@@ -6,7 +6,7 @@ use DuncanMcClean\SimpleCommerce\Contracts\OrderRepository;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \DuncanMcClean\SimpleCommerce\Contracts\OrderRepository
+ * @see OrderRepository
  */
 class Order extends Facade
 {

--- a/src/Facades/Product.php
+++ b/src/Facades/Product.php
@@ -6,7 +6,7 @@ use DuncanMcClean\SimpleCommerce\Contracts\ProductRepository;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \DuncanMcClean\SimpleCommerce\Contracts\ProductRepository
+ * @see ProductRepository
  */
 class Product extends Facade
 {

--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -2,6 +2,7 @@
 
 namespace DuncanMcClean\SimpleCommerce\Http\Controllers;
 
+use DuncanMcClean\SimpleCommerce\Contracts\Customer;
 use DuncanMcClean\SimpleCommerce\Facades\Product;
 use DuncanMcClean\SimpleCommerce\Http\Controllers\Concerns\HandlesCustomerInformation;
 use DuncanMcClean\SimpleCommerce\Http\Requests\CartItem\DestroyRequest;
@@ -47,7 +48,7 @@ class CartItemController extends BaseActionController
 
         // If this product requires another one, ensure the customer has already purchased it...
         if ($product->has('prerequisite_product')) {
-            /** @var \DuncanMcClean\SimpleCommerce\Contracts\Customer $customer */
+            /** @var Customer $customer */
             $customer = $cart->customer();
 
             if (! $customer) {

--- a/src/Http/Controllers/Concerns/HandlesCustomerInformation.php
+++ b/src/Http/Controllers/Concerns/HandlesCustomerInformation.php
@@ -3,6 +3,7 @@
 namespace DuncanMcClean\SimpleCommerce\Http\Controllers\Concerns;
 
 use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository;
 use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
 use DuncanMcClean\SimpleCommerce\Facades\Customer;
 use DuncanMcClean\SimpleCommerce\SimpleCommerce;
@@ -17,7 +18,7 @@ trait HandlesCustomerInformation
         // When the customer driver is set to users, a user is logged in, and the cart doesn't have a customer,
         // we'll set the customer to the logged in user.
         if (
-            $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class)
+            $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], UserCustomerRepository::class)
             && Auth::check()
             && ! $cart->customer()
         ) {

--- a/src/Http/Middleware/EnsureFormParametersArriveIntact.php
+++ b/src/Http/Middleware/EnsureFormParametersArriveIntact.php
@@ -5,16 +5,19 @@ namespace DuncanMcClean\SimpleCommerce\Http\Middleware;
 use Closure;
 use DuncanMcClean\SimpleCommerce\Exceptions\InvalidFormParametersException;
 use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class EnsureFormParametersArriveIntact
 {
     /**
      * Handle the incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @param  Request  $request
+     * @return Response
      *
-     * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     * @throws AccessDeniedHttpException
      */
     public function handle($request, Closure $next)
     {

--- a/src/Http/Resources/BaseResource.php
+++ b/src/Http/Resources/BaseResource.php
@@ -2,6 +2,7 @@
 
 namespace DuncanMcClean\SimpleCommerce\Http\Resources;
 
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class BaseResource extends JsonResource
@@ -9,7 +10,7 @@ class BaseResource extends JsonResource
     /**
      * Transform the resource into an array.
      *
-     * @param \Illuminate\Http\Request
+     * @param Request
      * @return array
      */
     public function toArray($request)

--- a/src/Listeners/RemoveCustomerFromOrder.php
+++ b/src/Listeners/RemoveCustomerFromOrder.php
@@ -2,6 +2,7 @@
 
 namespace DuncanMcClean\SimpleCommerce\Listeners;
 
+use DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository;
 use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Auth\Events\Logout;
@@ -12,7 +13,7 @@ class RemoveCustomerFromOrder
 
     public function handle(Logout $event)
     {
-        if (! $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class)) {
+        if (! $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], UserCustomerRepository::class)) {
             return;
         }
 

--- a/src/Notifications/BackOfficeOrderPaid.php
+++ b/src/Notifications/BackOfficeOrderPaid.php
@@ -35,7 +35,7 @@ class BackOfficeOrderPaid extends Notification
      * Get the mail representation of the notification.
      *
      * @param  mixed  $notifiable
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/src/Notifications/CustomerOrderPaid.php
+++ b/src/Notifications/CustomerOrderPaid.php
@@ -35,7 +35,7 @@ class CustomerOrderPaid extends Notification
      * Get the mail representation of the notification.
      *
      * @param  mixed  $notifiable
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/src/Notifications/CustomerOrderShipped.php
+++ b/src/Notifications/CustomerOrderShipped.php
@@ -35,7 +35,7 @@ class CustomerOrderShipped extends Notification
      * Get the mail representation of the notification.
      *
      * @param  mixed  $notifiable
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/src/Notifications/DigitalDownloadsNotification.php
+++ b/src/Notifications/DigitalDownloadsNotification.php
@@ -40,7 +40,7 @@ class DigitalDownloadsNotification extends Notification
      * Get the mail representation of the notification.
      *
      * @param  mixed  $notifiable
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/src/Orders/EntryOrderRepository.php
+++ b/src/Orders/EntryOrderRepository.php
@@ -10,6 +10,7 @@ use DuncanMcClean\SimpleCommerce\Facades\Customer;
 use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Statamic\Eloquent\Entries\EntryModel;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Stache;
 
@@ -175,7 +176,7 @@ class EntryOrderRepository implements RepositoryContract
 
     protected function isUsingEloquentDriverWithIncrementingIds(): bool
     {
-        return config('statamic.eloquent-driver.entries.model') === \Statamic\Eloquent\Entries\EntryModel::class;
+        return config('statamic.eloquent-driver.entries.model') === EntryModel::class;
     }
 
     protected function generateOrderNumber(): int

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,11 +3,20 @@
 namespace DuncanMcClean\SimpleCommerce;
 
 use Barryvdh\Debugbar\Facade as Debugbar;
+use DuncanMcClean\SimpleCommerce\Customers\EloquentCustomerRepository;
+use DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository;
+use DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository;
 use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CookieDriver;
+use DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
 use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Products\EntryProductRepository;
 use DuncanMcClean\SimpleCommerce\Support\Runway;
+use Illuminate\Auth\Events\Logout;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Carbon;
+use Statamic\Contracts\Auth\User;
 use Statamic\Events\EntryBlueprintFound;
 use Statamic\Events\UserBlueprintFound;
 use Statamic\Facades\Collection;
@@ -90,7 +99,7 @@ class ServiceProvider extends AddonServiceProvider
         Events\DigitalDownloadReady::class => [
             Listeners\SendConfiguredNotifications::class,
         ],
-        \Illuminate\Auth\Events\Logout::class => [
+        Logout::class => [
             Listeners\RemoveCustomerFromOrder::class,
         ],
     ];
@@ -257,7 +266,7 @@ class ServiceProvider extends AddonServiceProvider
         if (! $this->app->bound(Contracts\CartDriver::class)) {
             $this->app->bind(
                 Contracts\CartDriver::class,
-                config('simple-commerce.cart.driver', \DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CookieDriver::class)
+                config('simple-commerce.cart.driver', CookieDriver::class)
             );
         }
 
@@ -309,7 +318,7 @@ class ServiceProvider extends AddonServiceProvider
     {
         Nav::extend(function ($nav) {
             if (
-                $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], \DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository::class)
+                $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EntryOrderRepository::class)
             ) {
                 $nav->create(__('Orders'))
                     ->section(__('Simple Commerce'))
@@ -318,7 +327,7 @@ class ServiceProvider extends AddonServiceProvider
                     ->icon(SimpleCommerce::svg('shop'));
             } elseif (
                 class_exists('StatamicRadPack\Runway\Runway') &&
-                $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], \DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository::class)
+                $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EloquentOrderRepository::class)
             ) {
                 $orderResource = Runway::orderModel();
 
@@ -330,7 +339,7 @@ class ServiceProvider extends AddonServiceProvider
             }
 
             if (
-                $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class)
+                $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], EntryCustomerRepository::class)
             ) {
                 $nav->create(__('Customers'))
                     ->section(__('Simple Commerce'))
@@ -338,16 +347,16 @@ class ServiceProvider extends AddonServiceProvider
                     ->can('view', Collection::find(SimpleCommerce::customerDriver()['collection']))
                     ->icon('users');
             } elseif (
-                $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class)
+                $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], UserCustomerRepository::class)
             ) {
                 $nav->create(__('Customers'))
                     ->section(__('Simple Commerce'))
                     ->route('users.index')
-                    ->can('index', \Statamic\Contracts\Auth\User::class)
+                    ->can('index', User::class)
                     ->icon('users');
             } elseif (
                 class_exists('StatamicRadPack\Runway\Runway') &&
-                $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DuncanMcClean\SimpleCommerce\Customers\EloquentCustomerRepository::class)
+                $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], EloquentCustomerRepository::class)
             ) {
                 $customerResource = Runway::customerModel();
 
@@ -433,7 +442,7 @@ class ServiceProvider extends AddonServiceProvider
     protected function registerComputedValues()
     {
         if (
-            $this->isOrExtendsClass(SimpleCommerce::productDriver()['repository'], \DuncanMcClean\SimpleCommerce\Products\EntryProductRepository::class)
+            $this->isOrExtendsClass(SimpleCommerce::productDriver()['repository'], EntryProductRepository::class)
         ) {
             Collection::computed(SimpleCommerce::productDriver()['collection'], 'raw_price', function ($entry, $value) {
                 return $entry->get('price');
@@ -441,7 +450,7 @@ class ServiceProvider extends AddonServiceProvider
         }
 
         if (
-            $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], \DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository::class)
+            $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EntryOrderRepository::class)
         ) {
             Collection::computed(SimpleCommerce::orderDriver()['collection'], 'order_date', function ($entry, $value) {
                 $order = Order::find($entry->id());

--- a/src/Tax/Standard/TaxEngine.php
+++ b/src/Tax/Standard/TaxEngine.php
@@ -53,7 +53,7 @@ class TaxEngine implements Contract
     {
         $product = $lineItem->product();
 
-        /** @var \DuncanMcClean\SimpleCommerce\Orders\Address */
+        /** @var Address */
         $address = config('simple-commerce.tax_engine_config.address') === 'billing'
             ? $order->billingAddress()
             : $order->shippingAddress();
@@ -133,7 +133,7 @@ class TaxEngine implements Contract
 
     protected function decideOnShippingRate(Order $order, ShippingMethod $shippingMethod): ?StandardTaxRate
     {
-        /** @var \DuncanMcClean\SimpleCommerce\Orders\Address */
+        /** @var Address */
         $address = config('simple-commerce.tax_engine_config.address') === 'billing'
             ? $order->billingAddress()
             : $order->shippingAddress();

--- a/tests/ComputedValuesTest.php
+++ b/tests/ComputedValuesTest.php
@@ -3,9 +3,10 @@
 use DuncanMcClean\SimpleCommerce\Facades\Order;
 use DuncanMcClean\SimpleCommerce\Facades\Product;
 use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Tests\TestCase;
 use Illuminate\Support\Carbon;
 
-uses(DuncanMcClean\SimpleCommerce\Tests\TestCase::class);
+uses(TestCase::class);
 uses(SetupCollections::class);
 
 test('product returns with raw price value', function () {

--- a/tests/Customers/EntryCustomerRepositoryTest.php
+++ b/tests/Customers/EntryCustomerRepositoryTest.php
@@ -168,7 +168,7 @@ it('can delete customer', function () {
         ])
         ->save();
 
-    expect($customer->resource())->toBeInstanceOf(\Statamic\Contracts\Entries\Entry::class);
+    expect($customer->resource())->toBeInstanceOf(Statamic\Contracts\Entries\Entry::class);
 
     $customer->delete();
 

--- a/tests/Customers/UserCustomerRepositoryTest.php
+++ b/tests/Customers/UserCustomerRepositoryTest.php
@@ -1,8 +1,11 @@
 <?php
 
 use DuncanMcClean\SimpleCommerce\Contracts\Customer as CustomerContract;
+use DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository;
 use DuncanMcClean\SimpleCommerce\Contracts\Order as ContractsOrder;
+use DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository;
 use DuncanMcClean\SimpleCommerce\Customers\StacheUserQueryBuilder;
+use DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository;
 use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
 use DuncanMcClean\SimpleCommerce\Facades\Customer;
 use DuncanMcClean\SimpleCommerce\Facades\Order;
@@ -16,8 +19,8 @@ use Statamic\Statamic;
 
 beforeEach(function () {
     Statamic::repository(
-        \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
-        \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class
+        CustomerRepository::class,
+        UserCustomerRepository::class
     );
 
     File::deleteDirectory(__DIR__.'/../__fixtures__/users');
@@ -27,8 +30,8 @@ beforeEach(function () {
 
 afterEach(function () {
     Statamic::repository(
-        \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
-        \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class
+        CustomerRepository::class,
+        EntryCustomerRepository::class
     );
 });
 

--- a/tests/Helpers/UseDatabaseContentDrivers.php
+++ b/tests/Helpers/UseDatabaseContentDrivers.php
@@ -2,6 +2,12 @@
 
 namespace DuncanMcClean\SimpleCommerce\Tests\Helpers;
 
+use DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository;
+use DuncanMcClean\SimpleCommerce\Contracts\OrderRepository;
+use DuncanMcClean\SimpleCommerce\Customers\CustomerModel;
+use DuncanMcClean\SimpleCommerce\Customers\EloquentCustomerRepository;
+use DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\OrderModel;
 use Illuminate\Support\Facades\File;
 
 trait UseDatabaseContentDrivers
@@ -25,22 +31,22 @@ trait UseDatabaseContentDrivers
         $this->runLaravelMigrations();
 
         $this->app['config']->set('simple-commerce.content.customers', [
-            'repository' => \DuncanMcClean\SimpleCommerce\Customers\EloquentCustomerRepository::class,
-            'model' => \DuncanMcClean\SimpleCommerce\Customers\CustomerModel::class,
+            'repository' => EloquentCustomerRepository::class,
+            'model' => CustomerModel::class,
         ]);
 
         $this->app['config']->set('simple-commerce.content.orders', [
-            'repository' => \DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository::class,
-            'model' => \DuncanMcClean\SimpleCommerce\Orders\OrderModel::class,
+            'repository' => EloquentOrderRepository::class,
+            'model' => OrderModel::class,
         ]);
 
         $this->app->bind(
-            \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
+            CustomerRepository::class,
             $this->app['config']->get('simple-commerce.content.customers.repository')
         );
 
         $this->app->bind(
-            \DuncanMcClean\SimpleCommerce\Contracts\OrderRepository::class,
+            OrderRepository::class,
             $this->app['config']->get('simple-commerce.content.orders.repository')
         );
     }

--- a/tests/Http/Controllers/CP/ResendNotificationsControllerTest.php
+++ b/tests/Http/Controllers/CP/ResendNotificationsControllerTest.php
@@ -18,7 +18,7 @@ it('can resend notifications for order statuses', function () {
 
     Config::set('simple-commerce.notifications', [
         'order_dispatched' => [
-            \DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderShipped::class => ['to' => 'customer'],
+            CustomerOrderShipped::class => ['to' => 'customer'],
         ],
     ]);
 
@@ -40,7 +40,7 @@ it('can resend notifications for payment statuses', function () {
 
     Config::set('simple-commerce.notifications', [
         'order_paid' => [
-            \DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderPaid::class => ['to' => 'customer'],
+            CustomerOrderPaid::class => ['to' => 'customer'],
         ],
     ]);
 

--- a/tests/Http/Controllers/CheckoutControllerTest.php
+++ b/tests/Http/Controllers/CheckoutControllerTest.php
@@ -2224,10 +2224,10 @@ test('can post checkout and ensure user is redirected', function () {
 
 test('can post checkout and ensure order paid notifications are sent', function () {
     config(['simple-commerce.notifications.order_paid' => [
-        \DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderPaid::class => [
+        CustomerOrderPaid::class => [
             'to' => 'customer',
         ],
-        \DuncanMcClean\SimpleCommerce\Notifications\BackOfficeOrderPaid::class => [
+        BackOfficeOrderPaid::class => [
             'to' => 'duncan@example.com',
         ],
     ]]);

--- a/tests/Listeners/EnforceUserBlueprintFieldsTest.php
+++ b/tests/Listeners/EnforceUserBlueprintFieldsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository;
+use DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository;
 use DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository;
 use DuncanMcClean\SimpleCommerce\Listeners\EnforceUserBlueprintFields;
 use Illuminate\Support\Facades\Config;
@@ -18,8 +20,8 @@ test('fields can be added to user blueprint', function () {
     ]);
 
     Statamic::repository(
-        \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
-        \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class
+        CustomerRepository::class,
+        UserCustomerRepository::class
     );
 
     File::deleteDirectory(__DIR__.'/../__fixtures__/users');
@@ -35,8 +37,8 @@ test('fields can be added to user blueprint', function () {
     $this->assertTrue($handle->hasField('orders'));
 
     Statamic::repository(
-        \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
-        \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class
+        CustomerRepository::class,
+        EntryCustomerRepository::class
     );
 });
 

--- a/tests/Orders/EntryOrderRepositoryTest.php
+++ b/tests/Orders/EntryOrderRepositoryTest.php
@@ -161,13 +161,13 @@ it('can save order', function () {
 
     $order->save();
 
-    expect($order->resource())->toBeInstanceOf(\Statamic\Contracts\Entries\Entry::class);
+    expect($order->resource())->toBeInstanceOf(Statamic\Contracts\Entries\Entry::class);
 });
 
 it('can delete order', function () {
     $order = Order::make()->id('one')->save();
 
-    expect($order->resource())->toBeInstanceOf(\Statamic\Contracts\Entries\Entry::class);
+    expect($order->resource())->toBeInstanceOf(Statamic\Contracts\Entries\Entry::class);
 
     $order->delete();
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -95,7 +95,7 @@ function buildCartWithProducts()
 
 function tag($tag)
 {
-    return Parse::template($tag, []);
+    return Parse::template($tag, [], trusted: true);
 }
 
 function fakeCart($cart = null)

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,8 @@
 <?php
 
+use DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository;
+use DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository;
+use DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository;
 use DuncanMcClean\SimpleCommerce\Facades\Order;
 use DuncanMcClean\SimpleCommerce\Facades\Product;
 use DuncanMcClean\SimpleCommerce\Tests\Helpers\RefreshContent;
@@ -129,12 +132,12 @@ function fakeCart($cart = null)
 function setupUserCustomerRepository(): void
 {
     Config::set('simple-commerce.content.customers', [
-        'repository' => \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class,
+        'repository' => UserCustomerRepository::class,
     ]);
 
     Statamic::repository(
-        \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
-        \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class
+        CustomerRepository::class,
+        UserCustomerRepository::class
     );
 
     File::deleteDirectory(__DIR__.'/../__fixtures__/users');
@@ -144,12 +147,12 @@ function setupUserCustomerRepository(): void
 function tearDownUserCustomerRepository(): void
 {
     Config::set('simple-commerce.content.customers', [
-        'repository' => \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class,
+        'repository' => EntryCustomerRepository::class,
         'collection' => 'customers',
     ]);
 
     Statamic::repository(
-        \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
-        \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class
+        CustomerRepository::class,
+        EntryCustomerRepository::class
     );
 }

--- a/tests/Products/EntryProductRepositoryTest.php
+++ b/tests/Products/EntryProductRepositoryTest.php
@@ -4,6 +4,7 @@ use DuncanMcClean\SimpleCommerce\Contracts\Product as ProductContract;
 use DuncanMcClean\SimpleCommerce\Exceptions\ProductNotFound;
 use DuncanMcClean\SimpleCommerce\Facades\Product;
 use DuncanMcClean\SimpleCommerce\Products\EntryQueryBuilder;
+use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\Stache;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 
@@ -69,13 +70,13 @@ it('can save product', function () {
 
     $product->save();
 
-    expect($product->resource())->toBeInstanceOf(\Statamic\Contracts\Entries\Entry::class);
+    expect($product->resource())->toBeInstanceOf(Entry::class);
 });
 
 it('can delete product', function () {
     $product = Product::make()->id('one')->price(1500)->save();
 
-    expect($product->resource())->toBeInstanceOf(\Statamic\Contracts\Entries\Entry::class);
+    expect($product->resource())->toBeInstanceOf(Entry::class);
 
     $product->delete();
 

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -14,6 +14,7 @@ use Statamic\Facades\Antlers;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
+use Statamic\Fields\Value;
 use Statamic\Statamic;
 
 uses(SetupCollections::class);
@@ -943,8 +944,8 @@ test('can get data from cart', function () {
 
     $usage = $this->tag->wildcard('note');
 
-    expect($usage instanceof \Statamic\Fields\Value || is_string($usage))->toBeTrue();
-    expect('Deliver by front door.')->toBe($usage instanceof \Statamic\Fields\Value ? $usage->value() : $usage);
+    expect($usage instanceof Value || is_string($usage))->toBeTrue();
+    expect('Deliver by front door.')->toBe($usage instanceof Value ? $usage->value() : $usage);
 });
 
 /**
@@ -963,8 +964,8 @@ test('can get data from cart when method should be converted to studly case', fu
 
     $usage = $this->tag->wildcard('raw_grand_total');
 
-    expect($usage instanceof \Statamic\Fields\Value || is_int($usage))->toBeTrue();
-    expect(1590)->toBe($usage instanceof \Statamic\Fields\Value ? $usage->value() : $usage);
+    expect($usage instanceof Value || is_int($usage))->toBeTrue();
+    expect(1590)->toBe($usage instanceof Value ? $usage->value() : $usage);
 });
 
 test('cant get data from cart if there is no cart', function () {
@@ -973,6 +974,6 @@ test('cant get data from cart if there is no cart', function () {
 
     $usage = $this->tag->wildcard('note');
 
-    expect($usage instanceof \Statamic\Fields\Value || is_string($usage))->toBeFalse();
-    expect(null)->toBe($usage instanceof \Statamic\Fields\Value ? $usage->value() : $usage);
+    expect($usage instanceof Value || is_string($usage))->toBeFalse();
+    expect(null)->toBe($usage instanceof Value ? $usage->value() : $usage);
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,8 @@ namespace DuncanMcClean\SimpleCommerce\Tests;
 use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\SessionDriver;
 use DuncanMcClean\SimpleCommerce\ServiceProvider;
 use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Tax\BasicTaxEngine;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\TaxEngine;
 use DuncanMcClean\SimpleCommerce\Tax\Standard\TaxEngine as StandardTaxEngine;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Blueprint;
@@ -113,11 +115,11 @@ abstract class TestCase extends AddonTestCase
 
     protected function useBasicTaxEngine()
     {
-        SimpleCommerce::setTaxEngine(\DuncanMcClean\SimpleCommerce\Tax\BasicTaxEngine::class);
+        SimpleCommerce::setTaxEngine(BasicTaxEngine::class);
     }
 
     protected function useStandardTaxEngine()
     {
-        SimpleCommerce::setTaxEngine(\DuncanMcClean\SimpleCommerce\Tax\Standard\TaxEngine::class);
+        SimpleCommerce::setTaxEngine(TaxEngine::class);
     }
 }


### PR DESCRIPTION
This pull request adds Laravel 13 support to Simple Commerce. Laravel 13 is due to be released [Early March](https://x.com/taylorotwell/status/2021555106269831216).

Depends on:
* [x] https://github.com/statamic/cms/pull/13870
* [x] https://github.com/Stillat/proteus/pull/37